### PR TITLE
Add mpfr-dev package needed for Libretiny builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN \
   apk add --no-cache \
     gcompat \
     git \
+    mpfr4-dev \
     iputils \
     openssl-dev \
     py3-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN \
   apk add --no-cache \
     gcompat \
     git \
-    mpfr4-dev \
+    mpfr-dev \
     iputils \
     openssl-dev \
     py3-pip \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -25,6 +25,7 @@ RUN \
   apk add --no-cache \
     gcompat \
     git \
+    mpfr-dev \
     iputils \
     openssl-dev \
     py3-pip \


### PR DESCRIPTION
When compiling esphome firmware for Beken devices, it complaint about many symbol relocation.
Adding mpfr-dev package solve it.